### PR TITLE
Move Tests namespace to "autoload-dev" section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Solution10\\Auth\\": "src",
+            "Solution10\\Auth\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Solution10\\Auth\\Tests\\": "tests"
         }
     }


### PR DESCRIPTION
This fixes #6 by moving the tests namespace to the autoload-dev section. No further configuration required.